### PR TITLE
Add drone swapping for surveilance mission

### DIFF
--- a/communication_software/communication_software/common/json_schemas.py
+++ b/communication_software/communication_software/common/json_schemas.py
@@ -320,6 +320,14 @@ class FrontendMessages:
         mission_type: Optional[str]
         coordinates: GoToParams
 
+    class NewMission(FrontendMessage):
+        msg_type: Literal["new_mission"] = "new_mission"
+        mission: dict
+
+    class RemoveMission(FrontendMessage):
+        msg_type: Literal["remove_mission"] = "remove_mission"
+        mission: dict
+
     class ActiveMissions(FrontendMessage):
         msg_type: Literal["active_missions"] = "active_missions"
         missions: list[dict]

--- a/communication_software/communication_software/drone_communication.py
+++ b/communication_software/communication_software/drone_communication.py
@@ -588,8 +588,15 @@ class DroneCommunication:
                         print(
                             f"Mission {message.mission_id} completed with go_home as last task. Marking mission as completed."
                         )
-                        MissionRegistry.update_status(
+                        mission = MissionRegistry.update_status(
                             message.mission_id, MissionStatus.COMPLETED
+                        )
+
+                        r.publish(
+                            DRONE_EVENT_CHANNEL,
+                            json_schemas.FrontendMessages.NewMission(
+                                mission=mission
+                            ).model_dump_json(),
                         )
 
                         # Check if there's a pending surveil mission to dispatch
@@ -597,14 +604,16 @@ class DroneCommunication:
                         if pending_surveil_raw:
                             try:
                                 pending_surveil = json.loads(pending_surveil_raw)
-                                pending_mission_id = pending_surveil["mission_id"]
+                                pending_mission = pending_surveil["mission"]
                                 coverage_corners = pending_surveil["coverage_corners"]
-                                new_drone_id = pending_surveil["new_drone_id"]
+                                new_drone_id = pending_mission["drone_id"]
 
                                 print(
-                                    f"[handle_task_event] Dispatching pending surveil mission {pending_mission_id} for drone {new_drone_id}"
+                                    f"[handle_task_event] Dispatching pending surveil mission {pending_mission['mission_id']} for drone {new_drone_id}"
                                 )
-                                MissionRegistry.dispatch_mission(pending_mission_id)
+                                surveil_mission = MissionRegistry.dispatch_mission(
+                                    pending_mission["mission_id"]
+                                )
                                 r.set(
                                     "watch_area_coverage", json.dumps(coverage_corners)
                                 )
@@ -614,6 +623,13 @@ class DroneCommunication:
 
                                 print(
                                     f"[handle_task_event] Replaced surveil mission: old drone {connection_id} -> new drone {new_drone_id}"
+                                )
+
+                                r.publish(
+                                    DRONE_EVENT_CHANNEL,
+                                    json_schemas.FrontendMessages.NewMission(
+                                        mission=surveil_mission
+                                    ).model_dump_json(),
                                 )
                             except Exception as exc:
                                 print(

--- a/communication_software/communication_software/drone_communication.py
+++ b/communication_software/communication_software/drone_communication.py
@@ -591,6 +591,35 @@ class DroneCommunication:
                         MissionRegistry.update_status(
                             message.mission_id, MissionStatus.COMPLETED
                         )
+
+                        # Check if there's a pending surveil mission to dispatch
+                        pending_surveil_raw = r.get("pending_surveil_mission")
+                        if pending_surveil_raw:
+                            try:
+                                pending_surveil = json.loads(pending_surveil_raw)
+                                pending_mission_id = pending_surveil["mission_id"]
+                                coverage_corners = pending_surveil["coverage_corners"]
+                                new_drone_id = pending_surveil["new_drone_id"]
+
+                                print(
+                                    f"[handle_task_event] Dispatching pending surveil mission {pending_mission_id} for drone {new_drone_id}"
+                                )
+                                MissionRegistry.dispatch_mission(pending_mission_id)
+                                r.set(
+                                    "watch_area_coverage", json.dumps(coverage_corners)
+                                )
+
+                                # Remove the pending mission from Redis
+                                r.delete("pending_surveil_mission")
+
+                                print(
+                                    f"[handle_task_event] Replaced surveil mission: old drone {connection_id} -> new drone {new_drone_id}"
+                                )
+                            except Exception as exc:
+                                print(
+                                    f"[handle_task_event] Error dispatching pending surveil mission: {exc}"
+                                )
+
                         return
 
                 next_task_raw = r.lpop(f"mission_{message.mission_id}_task_queue")

--- a/communication_software/communication_software/frontend_websocket.py
+++ b/communication_software/communication_software/frontend_websocket.py
@@ -382,6 +382,18 @@ def abort_mission(mission_id: str):
         return {"msg_type": "response", "error": str(e)}
 
 
+@app.post("/api/v1/missions/abort_all")
+def abort_all_missions(mission_id: str):
+    try:
+        missions = MissionRegistry.get_all()
+        for mission in missions:
+            MissionRegistry.abort_mission(mission["mission_id"], False)
+
+        return {"status": "aborted", "mission_id": mission_id}
+    except Exception as e:
+        return {"msg_type": "response", "error": str(e)}
+
+
 @app.post("/api/v1/missions/return_home/{drone_id}")
 def return_home(drone_id: str):
     try:

--- a/communication_software/communication_software/missions_planning/auto_mission_suggest.py
+++ b/communication_software/communication_software/missions_planning/auto_mission_suggest.py
@@ -23,6 +23,7 @@ from communication_software.missions_planning.mission_registry import MissionReg
 COOLDOWN_SECONDS = 60.0
 DEDUP_DISTANCE_METERS = 10.0
 GROUND_ALTITUDE = 0.0
+BATTERY_THRESHOLD = 20.0  # Battery level threshold for replacement
 
 
 class AutoMissionSuggester:
@@ -63,6 +64,8 @@ class AutoMissionSuggester:
         self._recent_detection_events: list[json_schemas.SingleDetection] = []
         self._stop_event = threading.Event()
         self._drone_id_on_surveil = None
+        self._battery_monitor_thread = threading.Thread(target=self.battery_monitor)
+        self._battery_monitor_thread.start()
 
     def request_stop(self) -> None:
         """Signals listeners to stop gracefully."""
@@ -247,8 +250,9 @@ class AutoMissionSuggester:
                         continue
 
                     print("[area_listener] Ny watch_area hittad, bearbetar...")
-                    coordinates, coverage_corners, min_rect_corners = (
-                        self._get_area_surveil_coordinates(points, diagonal_fov=82.6)
+                    # Initial coordinates for potential error response
+                    initial_coordinates, _, _ = self._get_area_surveil_coordinates(
+                        points, diagonal_fov=82.6
                     )
 
                     if (self._drone_id_on_surveil is not None) and (
@@ -259,47 +263,20 @@ class AutoMissionSuggester:
                         )
                         self.send_response(
                             request_id,
-                            coordinates,
+                            initial_coordinates,
                             "A drone is already on a GotoAndSurveil mission, will not dispatch a new one",
                         )
                         continue
 
-                    surveil_mission = select_drone_for_mission(
-                        mission_type=GotoAndSurveil,
-                        coordinates=coordinates,
-                        params={"duration_seconds": None},
+                    surveil_mission, coverage_corners, min_rect_corners, message = (
+                        self._create_surveil_mission(points)
                     )
-
-                    if surveil_mission:
-                        # As we must know the fov to be able to determine the area, but we also must have a coordinate to decide what drone to use,
-                        # we have to do a preliminary coordinate calculation here to be able to select a drone, and then recalculate the coordinates with the correct fov for the selected drone.
-                        drone_id = surveil_mission.drone_id
-                        diagonal_fov = json_schemas.parse_capabilities(
-                            self._redis.get(f"capabilities_drone{drone_id}")
-                        ).camera.diagonal_fov
-
-                        coordinates, coverage_corners, min_rect_corners = (
-                            self._get_area_surveil_coordinates(
-                                points, diagonal_fov=diagonal_fov
-                            )
-                        )
-
-                        surveil_mission = select_drone_for_mission(
-                            mission_type=GotoAndSurveil,
-                            coordinates=coordinates,
-                            params={"duration_seconds": None},
-                        )
-
-                        if surveil_mission is None:
-                            print(
-                                f"[area_listener] No drone available for GotoAndSurveil after recalculating coordinates with correct FOV"
-                            )
 
                     if surveil_mission is None:
                         self.send_response(
                             request_id,
-                            coordinates,
-                            "No drone available for GotoAndSurveil mission",
+                            initial_coordinates,
+                            message,
                         )
                         continue
 
@@ -336,6 +313,117 @@ class AutoMissionSuggester:
 
         except Exception as exc:
             print(f"[area_listener] Error in Redis listener: {exc}")
+
+    def _create_surveil_mission(self, normalized_points, exclude_drone_id=None):
+        """
+        Creates a surveil mission for the given points, selecting an appropriate drone.
+        Returns mission, coverage_corners, min_rect_corners, error_message (None if success).
+        """
+        if len(normalized_points) < 3:
+            return None, None, None, "Not enough points"
+
+        # Initial calculation with default FOV
+        coordinates, coverage_corners, min_rect_corners = (
+            self._get_area_surveil_coordinates(normalized_points, diagonal_fov=82.6)
+        )
+
+        surveil_mission = select_drone_for_mission(
+            mission_type=GotoAndSurveil,
+            coordinates=coordinates,
+            params={"duration_seconds": None},
+        )
+
+        if surveil_mission is None:
+            return None, None, None, "No drone available"
+
+        if exclude_drone_id and surveil_mission.drone_id == exclude_drone_id:
+            return None, None, None, "Only excluded drone available"
+
+        # Recalculate with correct FOV
+        drone_id = surveil_mission.drone_id
+        diagonal_fov = json_schemas.parse_capabilities(
+            self._redis.get(f"capabilities_drone{drone_id}")
+        ).camera.diagonal_fov
+
+        coordinates, coverage_corners, min_rect_corners = (
+            self._get_area_surveil_coordinates(
+                normalized_points, diagonal_fov=diagonal_fov
+            )
+        )
+
+        surveil_mission = select_drone_for_mission(
+            mission_type=GotoAndSurveil,
+            coordinates=coordinates,
+            params={"duration_seconds": None},
+        )
+
+        if surveil_mission is None or (
+            exclude_drone_id and surveil_mission.drone_id == exclude_drone_id
+        ):
+            return None, None, None, "No suitable drone after FOV adjustment"
+
+        return surveil_mission, coverage_corners, min_rect_corners, None
+
+    def battery_monitor(self):
+        """
+        Continuously monitors battery levels of all drones.
+        If the surveil drone's battery is below threshold, dispatches a new surveil mission with another drone.
+        """
+        while not self._stop_event.is_set():
+            if self._drone_id_on_surveil is not None:
+                for key in self._redis.scan_iter(match="telemetry_drone*"):
+                    drone_id = key.replace("telemetry_drone", "")
+                    raw = self._redis.get(key)
+                    if raw:
+                        try:
+                            telemetry = json_schemas.parse_telemetry(raw)
+                            if (
+                                telemetry.battery_percent < BATTERY_THRESHOLD
+                                and drone_id == self._drone_id_on_surveil
+                            ):
+                                print(
+                                    f"Battery low for drone {drone_id} ({telemetry.battery_percent}%), attempting to replace surveil mission."
+                                )
+                                self._replace_surveil_mission()
+                        except Exception as exc:
+                            print(
+                                f"Failed to parse telemetry for drone {drone_id}: {exc}"
+                            )
+            self._sleep_with_stop_check(5.0)  # Check every 5 seconds
+
+    def _replace_surveil_mission(self):
+        """
+        Replaces the current surveil mission with a new one using a different drone.
+        """
+        points_raw = self._redis.get("watch_area")
+        if not points_raw:
+            print("No watch area stored, cannot replace surveil mission.")
+            return
+
+        points = json.loads(points_raw)["points"]
+        normalized_points = self._extract_watch_area_points(points)
+
+        surveil_mission, coverage_corners, _min_rect_corners, message = (
+            self._create_surveil_mission(
+                normalized_points, exclude_drone_id=self._drone_id_on_surveil
+            )
+        )
+
+        if surveil_mission is None:
+            print(f"Failed to replace surveil mission: {message}")
+            return
+
+        MissionRegistry.store(surveil_mission)
+        MissionRegistry.dispatch_mission(surveil_mission.mission_id)
+        old_drone = self._drone_id_on_surveil
+        self._drone_id_on_surveil = surveil_mission.drone_id
+        self._redis.set(
+            "watch_area_coverage",
+            json.dumps(coverage_corners),
+        )
+        print(
+            f"Replaced surveil mission: old drone {old_drone} -> new drone {surveil_mission.drone_id}"
+        )
 
     def object_listener(self):
         """

--- a/communication_software/communication_software/missions_planning/auto_mission_suggest.py
+++ b/communication_software/communication_software/missions_planning/auto_mission_suggest.py
@@ -19,6 +19,7 @@ from .drone_selector import select_drone_for_mission
 from communication_software.missions_planning.mission_status import MissionStatus
 from communication_software.constants import DRONE_EVENT_CHANNEL, SURVEIL_AREA_CHANNEL
 from communication_software.missions_planning.mission_registry import MissionRegistry
+from communication_software.missions_planning.mission_status import MissionStatus
 
 COOLDOWN_SECONDS = 60.0
 DEDUP_DISTANCE_METERS = 10.0
@@ -256,7 +257,9 @@ class AutoMissionSuggester:
                     )
 
                     if (self._drone_id_on_surveil is not None) and (
-                        MissionRegistry.is_drone_dispatched(self._drone_id_on_surveil)
+                        MissionRegistry.is_drone_dispatched_or_waiting(
+                            self._drone_id_on_surveil
+                        )
                     ):
                         print(
                             "[area_listener] A drone is already on a GotoAndSurveil mission, will not dispatch a new one"
@@ -370,6 +373,9 @@ class AutoMissionSuggester:
         If the surveil drone's battery is below threshold, dispatches a new surveil mission with another drone.
         """
         while not self._stop_event.is_set():
+            # Check if pending surveil mission has been deployed
+            self._check_pending_surveil_deployment()
+
             if self._drone_id_on_surveil is not None:
                 for key in self._redis.scan_iter(match="telemetry_drone*"):
                     drone_id = key.replace("telemetry_drone", "")
@@ -384,16 +390,42 @@ class AutoMissionSuggester:
                                 print(
                                     f"Battery low for drone {drone_id} ({telemetry.battery_percent}%), attempting to replace surveil mission."
                                 )
-                                self._replace_surveil_mission()
+                                self._add_pending_surveil_mission()
                         except Exception as exc:
                             print(
                                 f"Failed to parse telemetry for drone {drone_id}: {exc}"
                             )
             self._sleep_with_stop_check(5.0)  # Check every 5 seconds
 
-    def _replace_surveil_mission(self):
+    def _check_pending_surveil_deployment(self):
+        """
+        Checks if a pending surveil mission has been deployed and updates the tracking.
+        This is called after drone_communication dispatches the pending mission upon go_home completion.
+        """
+        pending_surveil_raw = self._redis.get("pending_surveil_mission")
+        if not pending_surveil_raw:
+            return
+
+        try:
+            pending_surveil = json.loads(pending_surveil_raw)
+            mission_id = pending_surveil.get("mission_id")
+            new_drone_id = pending_surveil.get("new_drone_id")
+
+            # Check if the mission is dispatched
+            mission = MissionRegistry.get(mission_id)
+            if mission and mission["status"] == MissionStatus.DISPATCHED.value:
+                print(
+                    f"[battery_monitor] Pending surveil mission {mission_id} has been deployed to drone {new_drone_id}"
+                )
+                self._drone_id_on_surveil = new_drone_id
+                # Note: Redis key will be cleaned up by drone_communication after dispatching
+        except Exception as exc:
+            print(f"[battery_monitor] Error checking pending surveil deployment: {exc}")
+
+    def _add_pending_surveil_mission(self):
         """
         Replaces the current surveil mission with a new one using a different drone.
+        Stores the new mission in Redis and sends the old drone home.
         """
         points_raw = self._redis.get("watch_area")
         if not points_raw:
@@ -413,17 +445,30 @@ class AutoMissionSuggester:
             print(f"Failed to replace surveil mission: {message}")
             return
 
-        MissionRegistry.store(surveil_mission)
-        MissionRegistry.dispatch_mission(surveil_mission.mission_id)
         old_drone = self._drone_id_on_surveil
-        self._drone_id_on_surveil = surveil_mission.drone_id
+
+        # Store the pending surveil mission in Redis to be dispatched after go_home completes
+        MissionRegistry.store(surveil_mission)
+        # Mark it as waiting so the drone appears busy
+        MissionRegistry.update_status(surveil_mission.mission_id, MissionStatus.WAITING)
         self._redis.set(
-            "watch_area_coverage",
-            json.dumps(coverage_corners),
+            f"pending_surveil_mission",
+            json.dumps(
+                {
+                    "mission_id": surveil_mission.mission_id,
+                    "coverage_corners": coverage_corners,
+                    "drone_id": surveil_mission.drone_id,
+                }
+            ),
         )
+
         print(
-            f"Replaced surveil mission: old drone {old_drone} -> new drone {surveil_mission.drone_id}"
+            f"[battery_monitor] Storing pending surveil mission {surveil_mission.mission_id} for drone {surveil_mission.drone_id}"
         )
+
+        # Send the old drone home
+        print(f"[battery_monitor] Sending drone {old_drone} home")
+        MissionRegistry.abort_mission_and_go_home(old_drone)
 
     def object_listener(self):
         """
@@ -453,7 +498,9 @@ class AutoMissionSuggester:
 
                 for detection in detections.root:
                     # Only propose missions if the drone is flying
-                    if MissionRegistry.is_drone_dispatched(detection.drone_ids[0]):
+                    if MissionRegistry.is_drone_dispatched_or_waiting(
+                        detection.drone_ids[0]
+                    ):
                         self.handle_detected_object(detection)
                     else:
                         print("Found detection but drone is not dispatched")

--- a/communication_software/communication_software/missions_planning/auto_mission_suggest.py
+++ b/communication_software/communication_software/missions_planning/auto_mission_suggest.py
@@ -185,9 +185,9 @@ class AutoMissionSuggester:
         if detection.detection_id:
             id_key = f"{detection.object_type}:{detection.detection_id}"
             if id_key in self._recent_detection_ids:
-                # print(
-                #     f"Skipping detection {detection.detection_id}, was already detection during cooldown period"
-                # )
+                print(
+                    f"Skipping detection {detection.detection_id}, was already detection during cooldown period"
+                )
                 return True
 
         lat = detection.gps_position[0]
@@ -488,7 +488,8 @@ class AutoMissionSuggester:
                     ):
                         self.handle_detected_object(detection)
                     else:
-                        print("Found detection but drone is not dispatched")
+                        pass
+                        # print("Found detection but drone is not dispatched")
 
             self._sleep_with_stop_check(0.5)
 
@@ -573,9 +574,9 @@ class AutoMissionSuggester:
             return
 
         if not self._is_detection_within_watch_area(detection.gps_position):
-            # print(
-            #     f"Detection {detection.detection_id} at {detection.gps_position[0]}, {detection.gps_position[1]} is outside watch area, skipping."
-            # )
+            print(
+                f"Detection {detection.detection_id} at {detection.gps_position[0]}, {detection.gps_position[1]} is outside watch area, skipping."
+            )
             return
 
         print(

--- a/communication_software/communication_software/missions_planning/auto_mission_suggest.py
+++ b/communication_software/communication_software/missions_planning/auto_mission_suggest.py
@@ -19,7 +19,6 @@ from .drone_selector import select_drone_for_mission
 from communication_software.missions_planning.mission_status import MissionStatus
 from communication_software.constants import DRONE_EVENT_CHANNEL, SURVEIL_AREA_CHANNEL
 from communication_software.missions_planning.mission_registry import MissionRegistry
-from communication_software.missions_planning.mission_status import MissionStatus
 
 COOLDOWN_SECONDS = 60.0
 DEDUP_DISTANCE_METERS = 10.0
@@ -64,7 +63,6 @@ class AutoMissionSuggester:
         self._recent_detection_ids: dict[str, float] = {}
         self._recent_detection_events: list[json_schemas.SingleDetection] = []
         self._stop_event = threading.Event()
-        self._drone_id_on_surveil = None
         self._battery_monitor_thread = threading.Thread(target=self.battery_monitor)
         self._battery_monitor_thread.start()
 
@@ -187,9 +185,9 @@ class AutoMissionSuggester:
         if detection.detection_id:
             id_key = f"{detection.object_type}:{detection.detection_id}"
             if id_key in self._recent_detection_ids:
-                print(
-                    f"Skipping detection {detection.detection_id}, was already detection during cooldown period"
-                )
+                # print(
+                #     f"Skipping detection {detection.detection_id}, was already detection during cooldown period"
+                # )
                 return True
 
         lat = detection.gps_position[0]
@@ -256,11 +254,10 @@ class AutoMissionSuggester:
                         points, diagonal_fov=82.6
                     )
 
-                    if (self._drone_id_on_surveil is not None) and (
-                        MissionRegistry.is_drone_dispatched_or_waiting(
-                            self._drone_id_on_surveil
-                        )
-                    ):
+                    current_surveil_drone = (
+                        MissionRegistry.get_drone_on_surveil_mission()
+                    )
+                    if current_surveil_drone is not None:
                         print(
                             "[area_listener] A drone is already on a GotoAndSurveil mission, will not dispatch a new one"
                         )
@@ -285,7 +282,6 @@ class AutoMissionSuggester:
 
                     print("[area_listener] GotoAndSurveil - dispatchar automatiskt")
 
-                    self._drone_id_on_surveil = surveil_mission.drone_id
                     MissionRegistry.store(surveil_mission)
                     MissionRegistry.dispatch_mission(surveil_mission.mission_id)
                     surveil_mission.status = MissionStatus.DISPATCHED
@@ -373,10 +369,8 @@ class AutoMissionSuggester:
         If the surveil drone's battery is below threshold, dispatches a new surveil mission with another drone.
         """
         while not self._stop_event.is_set():
-            # Check if pending surveil mission has been deployed
-            self._check_pending_surveil_deployment()
-
-            if self._drone_id_on_surveil is not None:
+            current_surveil_drone = MissionRegistry.get_drone_on_surveil_mission()
+            if current_surveil_drone is not None:
                 for key in self._redis.scan_iter(match="telemetry_drone*"):
                     drone_id = key.replace("telemetry_drone", "")
                     raw = self._redis.get(key)
@@ -384,43 +378,33 @@ class AutoMissionSuggester:
                         try:
                             telemetry = json_schemas.parse_telemetry(raw)
                             if (
-                                telemetry.battery_percent < BATTERY_THRESHOLD
-                                and drone_id == self._drone_id_on_surveil
+                                telemetry.battery_percent <= BATTERY_THRESHOLD
+                                and drone_id == current_surveil_drone
                             ):
                                 print(
                                     f"Battery low for drone {drone_id} ({telemetry.battery_percent}%), attempting to replace surveil mission."
                                 )
                                 self._add_pending_surveil_mission()
+
+                                # Send the old drone home, even if we can't find a replacement
+                                print(
+                                    f"[battery_monitor] Sending drone {drone_id} home"
+                                )
+                                go_home_mission = (
+                                    MissionRegistry.abort_mission_and_go_home(drone_id)
+                                )
+
+                                self._redis.publish(
+                                    DRONE_EVENT_CHANNEL,
+                                    json_schemas.FrontendMessages.NewMission(
+                                        mission=go_home_mission
+                                    ).model_dump_json(),
+                                )
                         except Exception as exc:
                             print(
                                 f"Failed to parse telemetry for drone {drone_id}: {exc}"
                             )
             self._sleep_with_stop_check(5.0)  # Check every 5 seconds
-
-    def _check_pending_surveil_deployment(self):
-        """
-        Checks if a pending surveil mission has been deployed and updates the tracking.
-        This is called after drone_communication dispatches the pending mission upon go_home completion.
-        """
-        pending_surveil_raw = self._redis.get("pending_surveil_mission")
-        if not pending_surveil_raw:
-            return
-
-        try:
-            pending_surveil = json.loads(pending_surveil_raw)
-            mission_id = pending_surveil.get("mission_id")
-            new_drone_id = pending_surveil.get("new_drone_id")
-
-            # Check if the mission is dispatched
-            mission = MissionRegistry.get(mission_id)
-            if mission and mission["status"] == MissionStatus.DISPATCHED.value:
-                print(
-                    f"[battery_monitor] Pending surveil mission {mission_id} has been deployed to drone {new_drone_id}"
-                )
-                self._drone_id_on_surveil = new_drone_id
-                # Note: Redis key will be cleaned up by drone_communication after dispatching
-        except Exception as exc:
-            print(f"[battery_monitor] Error checking pending surveil deployment: {exc}")
 
     def _add_pending_surveil_mission(self):
         """
@@ -435,9 +419,10 @@ class AutoMissionSuggester:
         points = json.loads(points_raw)["points"]
         normalized_points = self._extract_watch_area_points(points)
 
-        surveil_mission, coverage_corners, _min_rect_corners, message = (
+        current_surveil_drone = MissionRegistry.get_drone_on_surveil_mission()
+        surveil_mission, _coverage_corners, _min_rect_corners, message = (
             self._create_surveil_mission(
-                normalized_points, exclude_drone_id=self._drone_id_on_surveil
+                normalized_points, exclude_drone_id=current_surveil_drone
             )
         )
 
@@ -445,30 +430,30 @@ class AutoMissionSuggester:
             print(f"Failed to replace surveil mission: {message}")
             return
 
-        old_drone = self._drone_id_on_surveil
-
         # Store the pending surveil mission in Redis to be dispatched after go_home completes
         MissionRegistry.store(surveil_mission)
         # Mark it as waiting so the drone appears busy
-        MissionRegistry.update_status(surveil_mission.mission_id, MissionStatus.WAITING)
+        surveil_mission_dict = MissionRegistry.update_status(
+            surveil_mission.mission_id, MissionStatus.WAITING
+        )
+        pending_surveil_mission_message = json_schemas.FrontendMessages.NewMission(
+            mission=surveil_mission_dict
+        )
+
         self._redis.set(
             f"pending_surveil_mission",
-            json.dumps(
-                {
-                    "mission_id": surveil_mission.mission_id,
-                    "coverage_corners": coverage_corners,
-                    "drone_id": surveil_mission.drone_id,
-                }
-            ),
+            pending_surveil_mission_message.model_dump_json(),
         )
 
         print(
             f"[battery_monitor] Storing pending surveil mission {surveil_mission.mission_id} for drone {surveil_mission.drone_id}"
         )
 
-        # Send the old drone home
-        print(f"[battery_monitor] Sending drone {old_drone} home")
-        MissionRegistry.abort_mission_and_go_home(old_drone)
+        # Notify frontend
+
+        self._redis.publish(
+            DRONE_EVENT_CHANNEL, pending_surveil_mission_message.model_dump_json()
+        )
 
     def object_listener(self):
         """
@@ -588,9 +573,9 @@ class AutoMissionSuggester:
             return
 
         if not self._is_detection_within_watch_area(detection.gps_position):
-            print(
-                f"Detection {detection.detection_id} at {detection.gps_position[0]}, {detection.gps_position[1]} is outside watch area, skipping."
-            )
+            # print(
+            #     f"Detection {detection.detection_id} at {detection.gps_position[0]}, {detection.gps_position[1]} is outside watch area, skipping."
+            # )
             return
 
         print(

--- a/communication_software/communication_software/missions_planning/drone_selector.py
+++ b/communication_software/communication_software/missions_planning/drone_selector.py
@@ -411,7 +411,7 @@ class DroneSelector:
         available: list[DroneCandidate] = []
 
         for candidate in candidates:
-            if not MissionRegistry.is_drone_dispatched(candidate.drone_id):
+            if not MissionRegistry.is_drone_dispatched_or_waiting(candidate.drone_id):
                 available.append(candidate)
             else:
                 logger.info(

--- a/communication_software/communication_software/missions_planning/mission_registry.py
+++ b/communication_software/communication_software/missions_planning/mission_registry.py
@@ -48,7 +48,7 @@ class MissionRegistry:
         )
 
     @staticmethod
-    def dispatch_mission(mission_id: str) -> Mission:
+    def dispatch_mission(mission_id: str) -> dict:
         mission = json.loads(r.get(f"mission_{mission_id}_state"))
 
         if MissionRegistry.is_drone_dispatched(mission["drone_id"]):
@@ -106,11 +106,17 @@ class MissionRegistry:
 
         r.publish(DRONE_COMMANDS_CHANNEL, abort_message.model_dump_json())
         r.publish(DRONE_EVENT_CHANNEL, abort_message.model_dump_json())
+        r.publish(
+            DRONE_EVENT_CHANNEL,
+            json_schemas.FrontendMessages.RemoveMission(
+                mission=mission
+            ).model_dump_json(),
+        )
 
         print("[Mission Registry] Sent abort command for drone", mission["drone_id"])
 
     @staticmethod
-    def abort_mission_and_go_home(drone_id: str) -> Mission:
+    def abort_mission_and_go_home(drone_id: str) -> dict:
         # Hitta aktivt mission för drönaren
         all_missions = MissionRegistry.get_all()
         active_mission = next(
@@ -133,7 +139,9 @@ class MissionRegistry:
             capabilities=json_schemas.Capabilities(
                 camera=None, spotlight=False, led=None, speaker=None
             ),
-            coordinates=json_schemas.GoToParams(lat=0, lon=0, alt=0),
+            coordinates=json_schemas.GoToParams(
+                lat=0, lon=0, alt=0
+            ),  # Just to have some coordinates, the drone ignores these and just go home
         )
 
         MissionRegistry.store(go_home_mission)
@@ -170,11 +178,12 @@ class MissionRegistry:
         return missions
 
     @staticmethod
-    def update_status(mission_id: str, status: MissionStatus):
+    def update_status(mission_id: str, status: MissionStatus) -> dict | None:
         mission = MissionRegistry.get(mission_id)
         if mission:
             mission["status"] = status.value
             r.set(f"mission_{mission_id}_state", json.dumps(mission))
+        return mission
 
     @staticmethod
     def update_task_status(mission_id: str, task_index: int, status: TaskStatus):
@@ -212,6 +221,19 @@ class MissionRegistry:
                     return True
 
         return False
+
+    @staticmethod
+    def get_drone_on_surveil_mission() -> str | None:
+        """
+        Returns the drone_id of the drone currently on a GotoAndSurveil mission.
+        Returns None if no drone is on a surveil mission.
+        """
+        for mission in MissionRegistry.get_all():
+            if mission.get("mission_type") == "GotoAndSurveil" and mission[
+                "status"
+            ] in [MissionStatus.DISPATCHED.value]:
+                return mission["drone_id"]
+        return None
 
     @staticmethod
     def remove(mission_id: str):

--- a/communication_software/communication_software/missions_planning/mission_registry.py
+++ b/communication_software/communication_software/missions_planning/mission_registry.py
@@ -56,6 +56,22 @@ class MissionRegistry:
                 f"Cannot dispatch drone {mission['drone_id']}, it is already on a mission"
             )
 
+        # if the drone has a waiting mission, only dispatch the mission_id if the waiting mission is the same as the mission_id, otherwise raise an exception
+        if MissionRegistry.is_drone_waiting(mission["drone_id"]):
+            waiting_mission = next(
+                (
+                    m
+                    for m in MissionRegistry.get_all()
+                    if m["drone_id"] == mission["drone_id"]
+                    and m["status"] == MissionStatus.WAITING.value
+                ),
+                None,
+            )
+            if waiting_mission and waiting_mission["mission_id"] != mission_id:
+                raise Exception(
+                    f"Cannot dispatch mission {mission_id} for drone {mission['drone_id']}, it has a waiting mission {waiting_mission['mission_id']}"
+                )
+
         mission["status"] = MissionStatus.DISPATCHED.value
 
         r.set(f"mission_{mission_id}_state", json.dumps(mission))
@@ -71,7 +87,10 @@ class MissionRegistry:
     def abort_mission(mission_id: str, exception_on_not_dispatched: bool = True):
         mission = json.loads(r.get(f"mission_{mission_id}_state"))
 
-        if not MissionRegistry.is_drone_dispatched(mission["drone_id"]):
+        # This should actually only be to check if the drone is dispatched, but looks complicated..
+        if not MissionRegistry.is_drone_dispatched(mission["drone_id"]) and (
+            not MissionRegistry.is_drone_waiting(mission["drone_id"])
+        ):
             if exception_on_not_dispatched:
                 raise Exception(
                     f"Cannot abort mission {mission_id}, drone {mission['drone_id']} is not on a mission"
@@ -99,8 +118,7 @@ class MissionRegistry:
                 m
                 for m in all_missions
                 if m["drone_id"] == drone_id
-                and m["status"]
-                in [MissionStatus.DISPATCHED.value, MissionStatus.PENDING.value]
+                and m["status"] in [MissionStatus.DISPATCHED.value]
             ),
             None,
         )
@@ -170,6 +188,27 @@ class MissionRegistry:
         for mission in MissionRegistry.get_all():
             if mission["drone_id"] == drone_id:
                 if mission["status"] == MissionStatus.DISPATCHED.value:
+                    return True
+
+        return False
+
+    @staticmethod
+    def is_drone_waiting(drone_id: str) -> bool:
+        for mission in MissionRegistry.get_all():
+            if mission["drone_id"] == drone_id:
+                if mission["status"] == MissionStatus.WAITING.value:
+                    return True
+
+        return False
+
+    @staticmethod
+    def is_drone_dispatched_or_waiting(drone_id: str) -> bool:
+        for mission in MissionRegistry.get_all():
+            if mission["drone_id"] == drone_id:
+                if mission["status"] in [
+                    MissionStatus.DISPATCHED.value,
+                    MissionStatus.WAITING.value,
+                ]:
                     return True
 
         return False

--- a/communication_software/communication_software/missions_planning/mission_status.py
+++ b/communication_software/communication_software/missions_planning/mission_status.py
@@ -3,10 +3,10 @@ from enum import Enum
 
 class MissionStatus(Enum):
     PENDING = "PENDING"
+    WAITING = "WAITING"
     DISPATCHED = "DISPATCHED"
     COMPLETED = "COMPLETED"
     FAILED = "FAILED"
-    ABORTED = "ABORTED"
 
 
 class TaskStatus(Enum):

--- a/docs/Mock drone.md
+++ b/docs/Mock drone.md
@@ -4,8 +4,8 @@ To test the semi-full functionality of the system without a drone connected, a m
 To run the mock drone websockets have to be installed: ```pip install websockets```.
 In the repo root, run ```python -m mock_drone.main```.
 
-Multiple drones can be started, but all drones except the first one needs to be passed a unique id as the first parameter. replace <drone_id> with an id. If a video path is provided, that video will be streamed
- ```python -m mock_drone.main <drone_id> <video_path>```
+Multiple drones can be started, but all drones except the first one needs to be passed a unique id as the first parameter. replace <drone_id> with an id. A video will be streamed. If the second argument is ```drain```, the battery will be drained. If not provided it has infinite battery.
+ ```python -m mock_drone.main <drone_id> <drain?>```
 
 
 The drone registers itself with full specs, and streams video if a video file is provided. It sends telemetry messages continuously.

--- a/docs/Redis.md
+++ b/docs/Redis.md
@@ -6,11 +6,12 @@
 | frame_drone{id}\_detections   | DetectionsSchema        | |
 | telemetry_drone{id}   | TelemetrySchema        | if it exists, the drone is connected |
 | capabilities_drone{id}   | CapabilitiesSchema        | If it exists, the drone is connected    |
-| model_drone{id}   | CapabilitiesSchema        | If it exists, the drone is connected    |
+| model_drone{id}   | String        | Model name for the drone     |
 | watch_area  | Points | polygon area the drone should monitor | 
 | watch_area_min_rect  | Points | List of 4 lat,lon corner pairs | 
 | watch_area_coverage_area  | Points | List of 4 lat,lon corner pairs | 
 | mission_{mission_id}_task_queue  | AnyTaskAction | Queue of remaining tasks for a mission | 
 | mission_{mission_id}_state  | Mission | Internal mission state | 
+| pending_surveil_mission | { mission_id, drone_id, coverage_corners } | If exists, pending surveil mission |
 
 For schemas, see ```json_schemas.py``` and ```missions.py```

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -164,7 +164,6 @@
         const BACKEND_URL_HTTP = "http://localhost:8000";
 
         // ── State ──────────────────────────────────────────────────────────────
-        const activeMissions = {};      // { "drone_id": "mission_id" }
         const markers = {};             // { "drone_id": leaflet marker }
         const lastDronePositions = {};  // { "drone_id": [lat, lon] }
         const specsLoaded = {};         // { "drone_id": true }
@@ -261,9 +260,6 @@
                 const response = await fetch(`${BACKEND_URL_HTTP}/api/v1/missions`);
                 const missions = await response.json();
                 activeMissionsData = missions.filter(mission => mission.status === "DISPATCHED" || mission.status === "WAITING");
-                activeMissionsData.forEach(mission => {
-                    activeMissions[mission.drone_id] = mission.mission_id;
-                });
                 updateActiveMissionsList(activeMissionsData);
             } catch (error) {
                 console.error("Failed to fetch missions:", error);
@@ -290,7 +286,6 @@
                     removeProposedMissionSetLocally(missionSetId);
                     bootstrap.Modal.getInstance(missionModal)?.hide();
                     alert("Mission dispatched ok");
-                    activeMissions[result.mission.drone_id] = result.mission.mission_id;
                     activeMissionsData.push(result.mission);
                     updateActiveMissionsList(activeMissionsData);
                 }
@@ -443,7 +438,7 @@
 
         // ── Abort mission ──────────────────────────────────────────────────────
         async function abortMission(droneId) {
-            const missionId = activeMissions[droneId];
+            const missionId = activeMissionsData.find(m => m.drone_id === droneId && m.status === "DISPATCHED")?.mission_id;
             if (!missionId) { alert("Ingen aktiv mission för " + droneId); return; }
             if (!confirm(`Avbryt mission för ${droneId}?`)) return;
 
@@ -455,7 +450,6 @@
                 const data = await response.json();
                 if (data.error) { alert("Fel: " + data.error); return; }
                 alert("Mission avbruten!");
-                delete activeMissions[droneId];
                 activeMissionsData = activeMissionsData.filter(m => m.drone_id !== droneId);
                 updateActiveMissionsList(activeMissionsData);
             } catch (error) {
@@ -474,7 +468,6 @@
                 const data = await response.json();
                 if (data.error) { alert("Fel: " + data.error); return; }
                 alert("Drönaren åker hem!");
-                delete activeMissions[droneId];
                 activeMissionsData = activeMissionsData.filter(m => m.drone_id !== droneId);
                 activeMissionsData.push(data.mission);
                 updateActiveMissionsList(activeMissionsData);
@@ -496,7 +489,6 @@
                 let response = await fetch(`${BACKEND_URL_HTTP}/api/v1/missions/return_home/${droneId}`, { method: "POST" });
                 const data = await response.json();
                 if (data.error) { alert("Fel: " + data.error); return; }
-                delete activeMissions[droneId];
                 activeMissionsData.push(data.mission);
             }
             alert("Alla drönare åker hem!");
@@ -1001,7 +993,7 @@
                 drone_ids: [droneId],
                 gps_position: [lat, lng],
                 object_type: "person",
-                detection_id: increasingDetectionId++,
+                detection_id: document.getElementById("detection_id").value || ++increasingDetectionId,
                 timestamp: Date.now()
             };
             fetch("/api/v1/set_detections", {
@@ -1180,7 +1172,6 @@
 
                         console.log(result.data.mission)
 
-                        activeMissions[result.data.mission.drone_id] = result.data.mission_id;
                         activeMissionsData.push(result.data.mission);
                         updateActiveMissionsList(activeMissionsData);
 
@@ -1286,7 +1277,6 @@
                 const droneId = data.drone_id;
                 removeDroneStatusCard(droneId);
                 removeVideoDropdownOptions(droneId);
-                delete activeMissions[droneId];
                 delete specsLoaded[droneId];
                 delete lastDronePositions[droneId];
                 if (markers[droneId]) {
@@ -1378,10 +1368,6 @@
                     activeMissionsData.push(incoming);
                 }
 
-                if (incoming.drone_id) {
-                    activeMissions[incoming.drone_id] = incoming.mission_id;
-                }
-
                 updateActiveMissionsList(activeMissionsData);
             }
 
@@ -1407,11 +1393,6 @@
                 } else {
                     // Insert new mission
                     activeMissionsData.push(incoming);
-                }
-
-                // Keep lookup map in sync
-                if (incoming.drone_id) {
-                    activeMissions[incoming.drone_id] = incoming.mission_id;
                 }
 
                 updateActiveMissionsList(activeMissionsData);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -75,6 +75,10 @@
                                         <button id="rthAllBtn" data-command="flight_return_to_home"
                                             class="btn btn-info btn-sm all-drone-command-btn"
                                             onclick="returnHomeAll()">Return Home All</button>
+                                        <button id="abortAllBtn" data-command="flight_abort"
+                                            class="btn btn-danger btn-sm all-drone-command-btn"
+                                            onclick="abortAll()">Abort All</button>
+
                                     </div>
 
                                     <div class="mt-3 p-2 border rounded bg-light">
@@ -493,6 +497,24 @@
             }
             alert("Alla drönare åker hem!");
             updateActiveMissionsList(activeMissionsData);
+        }
+
+        async function abortAll() {
+            if (!confirm(`Avbryt mission för alla drönare?`)) return;
+
+            try {
+                const response = await fetch(
+                    `${BACKEND_URL_HTTP}/api/v1/missions/abort_all/`,
+                    { method: "POST" }
+                );
+                const data = await response.json();
+                if (data.error) { alert("Fel: " + data.error); return; }
+                alert("All Missions cancelled!");
+                activeMissionsData = []
+                updateActiveMissionsList(activeMissionsData);
+            } catch (error) {
+                console.error("Abort all misslyckades:", error);
+            }
         }
 
         // ── Mission buttons ────────────────────────────────────────────────────

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -179,6 +179,7 @@
                 case 'FAILED': return 'text-danger';
                 case 'PENDING': return 'text-primary';
                 case 'IN_PROGRESS': return 'text-warning';
+                case 'WAITING': return 'text-info';
                 default: return 'text-muted';
             }
         }
@@ -189,6 +190,7 @@
                 case 'FAILED': return '❌';
                 case 'PENDING': return '🔄';
                 case 'IN_PROGRESS': return '⏳';
+                case 'WAITING': return '⏱️';
                 default: return '❓';
             }
         }
@@ -218,7 +220,13 @@
                     const status = mission.task_status[index] || 'PENDING';
                     const statusClass = getStatusClass(status);
                     const emoji = getStatusEmoji(status);
-                    return `<li class="list-group-item d-flex justify-content-between align-items-center">
+                    let bgColor = '';
+                    if (status === 'COMPLETED') {
+                        bgColor = 'background-color: #d4edda;'; // light green
+                    } else if (status === 'WAITING') {
+                        bgColor = 'background-color: #cfe2ff;'; // light blue
+                    }
+                    return `<li class="list-group-item d-flex justify-content-between align-items-center" style="${bgColor}">
                         Task: ${task.action} <span class="${statusClass}">${emoji}</span>
                     </li>`;
                 }).join('');
@@ -228,7 +236,7 @@
                 html += `
                     <div class="active-mission mb-2">
                         <div class="mission-summary p-2 border rounded bg-light" data-mission-id="${mission.mission_id}" onclick="toggleMissionTasks(this)" style="cursor: pointer;">
-                            Mission for Drone ${mission.drone_id} - ${mission.mission_type || 'Unknown'}
+                            [${mission.status}] Mission for Drone ${mission.drone_id} - ${mission.mission_type || 'Unknown'}
                         </div>
                         <div class="mission-tasks" style="display: block;">
                             <ul class="list-group list-group-flush">${tasksHtml}</ul>
@@ -252,7 +260,7 @@
             try {
                 const response = await fetch(`${BACKEND_URL_HTTP}/api/v1/missions`);
                 const missions = await response.json();
-                activeMissionsData = missions.filter(mission => mission.status === "DISPATCHED");
+                activeMissionsData = missions.filter(mission => mission.status === "DISPATCHED" || mission.status === "WAITING");
                 activeMissionsData.forEach(mission => {
                     activeMissions[mission.drone_id] = mission.mission_id;
                 });
@@ -483,7 +491,7 @@
         // ── Return home all ────────────────────────────────────────────────────
         async function returnHomeAll() {
             if (!confirm("Skicka hem ALLA drönare?")) return;
-            activeMissionsData = [];
+            // activeMissionsData = [];
             for (const droneId of connectedDroneIds) {
                 let response = await fetch(`${BACKEND_URL_HTTP}/api/v1/missions/return_home/${droneId}`, { method: "POST" });
                 const data = await response.json();
@@ -1348,6 +1356,75 @@
                             updateActiveMissionsList(activeMissionsData);
                         }
                     })();
+                }
+            }
+
+            if (data.msg_type === "new_surveil_mission") {
+                const incoming = data.mission;
+                if (!incoming || !incoming.mission_id) return;
+
+                const index = activeMissionsData.findIndex(
+                    m => m.mission_id === incoming.mission_id
+                );
+
+                if (index !== -1) {
+                    // Update existing mission
+                    activeMissionsData[index] = {
+                        ...activeMissionsData[index],
+                        ...incoming
+                    };
+                } else {
+                    // Add new mission
+                    activeMissionsData.push(incoming);
+                }
+
+                if (incoming.drone_id) {
+                    activeMissions[incoming.drone_id] = incoming.mission_id;
+                }
+
+                updateActiveMissionsList(activeMissionsData);
+            }
+
+            if (data.msg_type === "remove_mission") {
+                activeMissionsData = activeMissionsData.filter(m => m.mission_id !== data.mission.mission_id);
+                updateActiveMissionsList(activeMissionsData);
+            }
+
+            if (data.msg_type === "new_mission") {
+                const incoming = data.mission;
+                if (!incoming || !incoming.mission_id) return;
+
+                const index = activeMissionsData.findIndex(
+                    m => m.mission_id === incoming.mission_id
+                );
+
+                if (index !== -1) {
+                    // Update existing mission (preserve object reference if needed)
+                    activeMissionsData[index] = {
+                        ...activeMissionsData[index],
+                        ...incoming
+                    };
+                } else {
+                    // Insert new mission
+                    activeMissionsData.push(incoming);
+                }
+
+                // Keep lookup map in sync
+                if (incoming.drone_id) {
+                    activeMissions[incoming.drone_id] = incoming.mission_id;
+                }
+
+                updateActiveMissionsList(activeMissionsData);
+
+                if (incoming.status === "COMPLETED") {
+                    (async () => {
+
+                        setTimeout(() => {
+                            activeMissionsData = activeMissionsData.filter(m => m.mission_id !== incoming.mission_id);
+                            updateActiveMissionsList(activeMissionsData);
+                        }, 3000);
+                    })
+                        ();
                 }
             }
         };

--- a/mock_drone/main.py
+++ b/mock_drone/main.py
@@ -21,6 +21,13 @@ import communication_software.communication_software.common.json_schemas as json
 SERVER_WS_URL = "ws://localhost:14500"
 DRONE_ID = "haubits_77"
 TELEMETRY_INTERVAL = 5
+BATTERY_DRAIN_PER_MINUTE = 20  # Battery decreases by 20% per minute
+
+# Battery tracking
+current_battery = 60.0
+battery_drain_per_interval = BATTERY_DRAIN_PER_MINUTE / (
+    60 / TELEMETRY_INTERVAL
+)  # Drain per 5s interval
 
 liseberg = (57.696162, 11.991556)
 VIDEO_PATH = "mock_drone/test_video_2024.mp4"
@@ -28,7 +35,12 @@ VIDEO_PATH = "mock_drone/test_video_2024.mp4"
 
 async def send_telemetry(websocket, drone_id: str):
     """Continuously sends telemetry using the TelemetryMessage class."""
+    global current_battery
+
     while True:
+        # Decrease battery
+        current_battery = int(max(0.0, current_battery - battery_drain_per_interval))
+
         # Create the Telemetry sub-model
         current_telemetry = json_schemas.Telemetry(
             lat=liseberg[0] + (random.uniform(-0.001, 0.001)),
@@ -36,7 +48,7 @@ async def send_telemetry(websocket, drone_id: str):
             alt=random.uniform(110, 120),
             heading=random.randint(0, 359),
             speed=random.uniform(0.0, 5.5),
-            battery_percent=88,
+            battery_percent=current_battery,
         )
 
         # Wrap in the TelemetryMessage envelope
@@ -202,7 +214,7 @@ async def run_drone_client(drone_id: str, video_path: Optional[str]):
                     alt=random.uniform(110, 120),
                     heading=random.randint(0, 359),
                     speed=random.uniform(0.0, 5.5),
-                    battery_percent=88,
+                    battery_percent=current_battery,
                 ),
             )
 

--- a/mock_drone/main.py
+++ b/mock_drone/main.py
@@ -24,7 +24,7 @@ TELEMETRY_INTERVAL = 5
 BATTERY_DRAIN_PER_MINUTE = 20  # Battery decreases by 20% per minute
 
 # Battery tracking
-current_battery = 60.0
+current_battery = 40.0
 battery_drain_per_interval = BATTERY_DRAIN_PER_MINUTE / (
     60 / TELEMETRY_INTERVAL
 )  # Drain per 5s interval
@@ -184,7 +184,9 @@ async def run_drone_client(drone_id: str, video_path: Optional[str]):
     try:
         wait_event: asyncio.Event = asyncio.Event()
         async with connect(SERVER_WS_URL) as websocket:
-            print(f"Connected to {SERVER_WS_URL} as drone {drone_id}")
+            print(
+                f"Connected to {SERVER_WS_URL} as drone {drone_id}, battery drain interval={battery_drain_per_interval}% every {TELEMETRY_INTERVAL}s"
+            )
 
             await asyncio.sleep(2)
 
@@ -298,6 +300,8 @@ async def run_drone_client(drone_id: str, video_path: Optional[str]):
 
 if __name__ == "__main__":
     drone_id = sys.argv[1] if len(sys.argv) > 1 else DRONE_ID
-    video_path = sys.argv[2] if len(sys.argv) > 2 else VIDEO_PATH
+    # if arg 2 is "drain" then set battery drain to default value for testing, otherwise 0
+    if len(sys.argv) <= 2 or sys.argv[2] != "drain":
+        battery_drain_per_interval = 0
 
-    asyncio.run(run_drone_client(drone_id, video_path))
+    asyncio.run(run_drone_client(drone_id, VIDEO_PATH))

--- a/mock_drone/main.py
+++ b/mock_drone/main.py
@@ -304,4 +304,4 @@ if __name__ == "__main__":
     if len(sys.argv) <= 2 or sys.argv[2] != "drain":
         battery_drain_per_interval = 0
 
-    asyncio.run(run_drone_client(drone_id, VIDEO_PATH))
+    asyncio.run(run_drone_client(drone_id, None))


### PR DESCRIPTION
### Description
- When a surveilling drone has battery <= 20%, it is sent home and it checks if another drone can take its place. If it can that drone gets a "WAITING" mission that is sent once the first drone lands safely
- Display and remove active missions properly, include status in the title
- Mock drone can be enabled to drain battery
- Add abort all button to cancel missions for disconnected drones

### Linked issue
Closes #127, Closes #144

### Checklist
- [ ] Added/Updated tests
- [ ] Tests passed
- [ ] Updated code or repo documentation
- [ ] Linked an issue
- [ ] Have reviewed my code (code and files follows naming conventions)
